### PR TITLE
Use curly syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "flex-js": "^1.0.5",
-    "js2amb": "aphelionz/js2amb#master",
+    "js2amb": "haadcode/js2amb#feat/curly-syntax",
     "mime-types": "^2.1.25",
     "multiaddr": "^7.2.1",
     "nearley": "^2.19.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -54,16 +54,21 @@ const argv = require('yargs')
   mime.extensions['text/ambients'] = ['ambient']
   mime.types.ambient = 'text/ambients'
 
-  const file = fs.readFileSync(argv.input).toString().trim()
-
   let result
-  switch (mime.lookup(argv.input)) {
-    case 'application/javascript':
-      result = await output(ipfs, file, argv); break
-    case 'text/ambients':
-      result = await output(ipfs, file, argv); break
-    default:
-      throw new Error('File type not recognized')
+
+  try {
+    const file = fs.readFileSync(argv.input).toString().trim()
+
+    switch (mime.lookup(argv.input)) {
+      case 'application/javascript':
+        result = await output(ipfs, file, argv); break
+      case 'text/ambients':
+        result = await output(ipfs, file, argv); break
+      default:
+        throw new Error('File type not recognized')
+    }
+  } catch (e) {
+    console.error(e)
   }
 
   process.stdout.write(result + '\n')

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const js = {
   parse: (js) => {
     const ambientSyntax = js2amb(js)
     const res = ambients.parse(ambientSyntax)
-    return JSON.stringify(res.toJS())
+    return res.toJS()
   }
 }
 
@@ -36,9 +36,9 @@ const output = async (ipfs, ambient, argv) => {
 
   // --display flag
   // -o option
-  if (argv.display) return result
+  if (argv.display) return JSON.stringify(result)
   if (argv.o) {
-    fs.writeFileSync(argv.o, result)
+    fs.writeFileSync(argv.o, JSON.stringify(result))
     return 'Wrote program to ' + argv.o
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const irParser = require('./ir')
-const parse = require('./parser')
+const parse = require('./nba-parser').parse
 const js2amb = require('js2amb')
 const io = require('orbit-db-io')
 const fs = require('fs')
@@ -13,7 +13,8 @@ const js = {
   },
   parse: (js) => {
     const ambientSyntax = js2amb(js)
-    return ambients.parse(ambientSyntax)
+    const res = ambients.parse(ambientSyntax)
+    return JSON.stringify(res.toJS())
   }
 }
 
@@ -35,8 +36,11 @@ const output = async (ipfs, ambient, argv) => {
 
   // --display flag
   // -o option
-  if (argv.display) return process.stdout.write(result)
-  if (argv.o) return fs.writeFileSync(argv.o, result)
+  if (argv.display) return result
+  if (argv.o) {
+    fs.writeFileSync(argv.o, result)
+    return 'Wrote program to ' + argv.o
+  }
 
   const hash = await io.write(ipfs, 'dag-cbor', result)
   return hash

--- a/src/nba-parser/nba-parser.ne
+++ b/src/nba-parser/nba-parser.ne
@@ -43,7 +43,7 @@ OUTS ->
     "out_" _ "(" NAME_BINDING _ "," _ NAME ")" {% ([,,,name,,,,pw]) => new ast.cocap('out_', [name, pw]) %}
 
 MESSAGE_OP ->
-    ":" NAME {% ([,name]) => new ast.subst(name)  %}
+    "{" NAME {% ([,name]) => new ast.subst(name)  %} "}"
 
 MESSAGE ->
     SEQUENTIAL {% id %} |


### PR DESCRIPTION
This PR will parse substitution ambients using the curly brace syntax.

It also fixes some issues with cli output.